### PR TITLE
외부링크페이지연결

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import Redirect from "./pages/Redirect";
 
 function App() {
   const url = "https://ebook.suwonlib.go.kr/";
+  const url2 = "https://www.suwonlib.go.kr/";
   return (
     <>
       <GlobalStyles />
@@ -23,7 +24,8 @@ function App() {
         <Route path='/localSearch' element={<LocalSearchPage />}></Route>
         <Route path='/categorySearch' element={<CategorySearch />}></Route>
         <Route path='/kdcSearch' element={<KdcSearchPage />}></Route>
-        <Route path='/redirect' element={<Redirect url={url} />}></Route>
+        <Route path='/redirectA' element={<Redirect url={url} />}></Route>
+        <Route path='/redirectB' element={<Redirect url={url2} />}></Route>
       </Routes>
       <Footer></Footer>
     </>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,7 +8,10 @@ import DiscoveryPage from "./pages/DiscoveryPage";
 import HeaderNavContainer from "./container/common/HeaderNavContainer";
 import KdcSearchPage from "./pages/KdcSearchPage";
 import Footer from "./components/common/Footer";
+import Redirect from "./pages/Redirect";
+
 function App() {
+  const url = "https://ebook.suwonlib.go.kr/";
   return (
     <>
       <GlobalStyles />
@@ -20,6 +23,7 @@ function App() {
         <Route path='/localSearch' element={<LocalSearchPage />}></Route>
         <Route path='/categorySearch' element={<CategorySearch />}></Route>
         <Route path='/kdcSearch' element={<KdcSearchPage />}></Route>
+        <Route path='/redirect' element={<Redirect url={url} />}></Route>
       </Routes>
       <Footer></Footer>
     </>

--- a/frontend/src/components/common/ExternalPage.js
+++ b/frontend/src/components/common/ExternalPage.js
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+import palette from "../../lib/styles/palette";
+
+const ExternalPageLink = styled.a`
+  display: block;
+  margin-bottom: 7px;
+  font-weight: 700;
+  color: ${palette.gray[9]};
+  font-size: 17px;
+`;
+
+function ExternalPage(props) {
+  return (
+    <ExternalPageLink href={props.href} hel={props.rel} target={props.target}>
+      {props.value}
+    </ExternalPageLink>
+  );
+}
+
+export default ExternalPage;

--- a/frontend/src/components/common/Header.js
+++ b/frontend/src/components/common/Header.js
@@ -111,7 +111,14 @@ const Header = () => {
     <>
       <UtilMenu>
         <WrapperUtil>
-          <div className='navBtn'>도서관사업소 바로가기</div>
+          <Link
+            to='/redirectB'
+            rel='noreferrer'
+            target='_blank'
+            className='navBtn'
+          >
+            도서관사업소 바로가기
+          </Link>
           <div className='navBtn'>로그인</div>
           <div className='navBtn'>내서재</div>
         </WrapperUtil>

--- a/frontend/src/components/common/SearchMain.js
+++ b/frontend/src/components/common/SearchMain.js
@@ -4,7 +4,6 @@ import Responsive from "./Responsive";
 import background from "../../lib/img/main/img_main_visual.png";
 import { Link } from "react-router-dom";
 import palette from "../../lib/styles/palette";
-import ExternalPage from "./ExternalPage";
 
 const Inner = styled(Responsive)`
   background-image: url(${background});
@@ -51,7 +50,7 @@ function SearchMain() {
     "/discovery/popularBook",
     "/discovery/accessionBook",
     "/discovery/libBook",
-    "/redirect",
+    "/redirectA",
     "/baroLoan",
     "/localSearch",
   ];

--- a/frontend/src/components/common/SearchMain.js
+++ b/frontend/src/components/common/SearchMain.js
@@ -4,6 +4,8 @@ import Responsive from "./Responsive";
 import background from "../../lib/img/main/img_main_visual.png";
 import { Link } from "react-router-dom";
 import palette from "../../lib/styles/palette";
+import ExternalPage from "./ExternalPage";
+
 const Inner = styled(Responsive)`
   background-image: url(${background});
   background-repeat: no-repeat;
@@ -49,7 +51,7 @@ function SearchMain() {
     "/discovery/popularBook",
     "/discovery/accessionBook",
     "/discovery/libBook",
-    "/",
+    "/redirect",
     "/baroLoan",
     "/localSearch",
   ];
@@ -61,8 +63,15 @@ function SearchMain() {
     "ico_main_link_12",
     "ico_main_link_11",
   ];
+
   const menuListRender = menuList.map((name, i) => (
-    <Link to={linkList[i]} className='list' key={i}>
+    <Link
+      to={linkList[i]}
+      className='list'
+      target={i === 3 ? "_blank" : null}
+      key={i}
+      value={name}
+    >
       <img
         src={require(`../../lib/img/main_icon/${imgSrc[i]}.png`)}
         alt={`ico_main_link_4${imgSrc[i]}`}

--- a/frontend/src/components/menu/MenuBar.js
+++ b/frontend/src/components/menu/MenuBar.js
@@ -6,6 +6,7 @@ import Dropdown from "../common/Dropdown";
 import Button from "../common/Button";
 import MenuImg from "../../lib/img/nav_icon/bg_gnb_01.png";
 import { Link } from "react-router-dom";
+import ExternalPage from "../common/ExternalPage";
 
 const MainMenuContainer = styled(Button)`
   z-index: 10001;
@@ -94,6 +95,15 @@ const GroupSideMenu = styled(Link)`
   font-size: 15px;
   color: ${palette.gray[9]};
 `;
+
+const ExternalPageLink = styled(ExternalPage)`
+  display: block;
+  margin-bottom: 7px;
+  font-weight: 700;
+  color: ${palette.gray[9]};
+  font-size: 17px;
+`;
+
 function MenuBar() {
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
 
@@ -125,7 +135,12 @@ function MenuBar() {
                 <br />
                 <GroupMenu to='/discovery/libBook'>추천도서</GroupMenu>
                 <br />
-                <GroupMenu to='/'>전자도서관</GroupMenu>
+                <ExternalPage
+                  href='https://ebook.suwonlib.go.kr/'
+                  rel='noreferrer'
+                  target='_blank'
+                  value='전자도서관'
+                ></ExternalPage>
                 <br />
               </Group>
               <Group>
@@ -133,7 +148,12 @@ function MenuBar() {
                 <br />
                 <GroupMenu to='/localSearch'>지역도서관 통합검색</GroupMenu>
                 <br />
-                <GroupMenu to='/'>이용안내</GroupMenu>
+                <ExternalPage
+                  href='http://www.suwonlib.go.kr:8080/download/AlpasQ_Manual.pdf'
+                  rel='noreferrer'
+                  target='_blank'
+                  value='이용안내'
+                ></ExternalPage>
                 <br />
               </Group>
             </WrapMenu>

--- a/frontend/src/components/menu/MenuBar.js
+++ b/frontend/src/components/menu/MenuBar.js
@@ -96,14 +96,6 @@ const GroupSideMenu = styled(Link)`
   color: ${palette.gray[9]};
 `;
 
-const ExternalPageLink = styled(ExternalPage)`
-  display: block;
-  margin-bottom: 7px;
-  font-weight: 700;
-  color: ${palette.gray[9]};
-  font-size: 17px;
-`;
-
 function MenuBar() {
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
 

--- a/frontend/src/pages/Redirect.js
+++ b/frontend/src/pages/Redirect.js
@@ -1,0 +1,11 @@
+import React, { useEffect } from "react";
+
+const Redirect = (props) => {
+  const { url } = props;
+  useEffect(() => {
+    window.location.href = url;
+  }, [url]);
+  return <h5>Redirecting...</h5>;
+};
+
+export default Redirect;


### PR DESCRIPTION
## 세부사항
외부링크 페이지 연결

## 어려웠던 점 또는 참고사항
react-router dom 내부에서 외부 페이지로 연결하는 기능을 찾지 못했다.
따라서 아래 url을 바탕으로 redirect page를 만들고 해당 페이지에 연결해서 외부페이지를 여는 방법을 선택했다.
[Redirecting to External URLs in React Router Dom v6](https://femto.hashnode.dev/redirecting-to-external-urls-in-react-router-dom-v6)
각 버튼마다 다른 주소로 이동하기 위해 props를 활용하여 해당 주소를 전달하는 방법을 고민하였으나 지나치게 복잡한 코드가 필요하고, 현재로서는 외부 페이지로 이동하는 주소가 많이 필요가 없어 해당 url에 대해 수작업으로 작성하였다.

작업리스트가운데 희망도서 page의 경우 로그인 모달기능, 및 로그인 페이지가 구현되어야 작성하기 좋으므로 다음에 만들기로 했다.

## 스크린샷
![image](https://user-images.githubusercontent.com/35355087/193863566-1a4b07b0-711a-4d45-85bd-8e9fdbae8651.png)
url 경로 수작업. 보다 나은 코드가 있는지 생각해보기...

## 실제 소요시간
4시간

## 관련 이슈

#17 