### PR TITLE
카테고리 분류 및 한국십진분류 페이지 생성

### DIFF
--- a/frontend/src/components/common/TestBox.js
+++ b/frontend/src/components/common/TestBox.js
@@ -1,0 +1,16 @@
+import React from "react";
+import styled from "styled-components";
+
+const TestBoxContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  min-height: 780px;
+  min-width: 780px;
+  background-color: aliceblue;
+`;
+
+function TestBox() {
+  return <TestBoxContainer></TestBoxContainer>;
+}
+
+export default TestBox;

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -78,8 +78,24 @@ const SCategoryMenu = styled.ul`
 // hover시 드롭다운 리스트 생성, 2중 리스트까지 나와야함.
 // 해당 리스트를 출력할 수 있는 방법은?
 //
+export const ToggleContainer = styled.div`
+  display: flex;
+`;
 
-const ToggleButton = styled(Button)``;
+export const ToggleButton = styled(Button)`
+  text-align: center;
+  line-height: 50px;
+  width: 220px;
+  height: 50px;
+  margin: 20px 5px;
+  padding: 0;
+  background-color: ${palette.gray[4]};
+  color: black;
+  &.active {
+    background-color: ${palette.blue[7]};
+    color: white;
+  }
+`;
 
 function Category() {
   const CL = CategoryList.contents.categoryList;
@@ -95,7 +111,12 @@ function Category() {
   const [sHover, setsHover] = useState("");
   return (
     <MainContainer>
-      <ToggleButton> test</ToggleButton>
+      <ToggleContainer>
+        <ToggleButton to='/categorySearch' className='active'>
+          카테고리분류
+        </ToggleButton>
+        <ToggleButton to='/kdcSearch'> 한국십진분류</ToggleButton>
+      </ToggleContainer>
       <CategroyContainer>
         {CL.map((v, i) => (
           <Fragment key={v.lCategoryCode}>

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -99,13 +99,8 @@ export const ToggleButton = styled(Button)`
 
 function Category() {
   const CL = CategoryList.contents.categoryList;
-  // console.log(CL.map((v) => v.lCategoryDesc));
-  // console.log(CL?.map((v) => v.mCategoryList));
+
   const CLmList = CL?.map((v) => v.mCategoryList);
-  // console.log(CL[0].mCategoryList[7].sCategoryList.map((v) => v.sCategoryDesc));
-  // console.log(
-  //   CLmList[0].map((v) => v.sCategoryList.map((v) => v.sCategoryDesc))
-  // );
 
   const [hover, setHover] = useState("");
   const [sHover, setsHover] = useState("");

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -15,20 +15,30 @@ const CategroyContainer = styled.div`
 `;
 
 const CategoryBox = styled.div`
-  min-width: 15%;
-  max-width: 15%;
+  width: 15%;
+
   min-height: 150px;
   max-height: 150px;
+  display: inline-block;
   background-color: ${palette.gray[4]};
   border: 1px solid green;
 `;
 
 const MCategoryMenu = styled.ul`
-  overflow: hidden;
-  position: relative;
-  top: 0;
-  width: 100%;
-  left: calc(100% + 10px);
+  left: ${CategoryBox.width};
+  /* overflow: hidden; */
+  /* display: flex; */
+  position: absolute;
+  display: block;
+  width: ${CategoryBox.width};
+  min-width: 15%;
+  border: 1px solid red;
+`;
+
+const SCategoryMenu = styled.ul`
+  position: absolute;
+  display: block;
+  width: ${CategoryBox.width};
   min-width: 15%;
   border: 1px solid red;
 `;
@@ -62,6 +72,7 @@ function Category() {
   // console.log(CLmList?.map((v) => v.mCategoryDesc));
 
   const [hover, setHover] = useState("");
+  const [sHover, setsHover] = useState("");
   return (
     <MainContainer onMouseLeave={() => setHover("")}>
       <CategroyContainer>
@@ -73,12 +84,16 @@ function Category() {
                 <MCategoryMenu>
                   {CLmList[i].map((v, i) => (
                     <Fragment key={i}>
-                      <li>{v.mCategoryDesc}</li>
-                      <MCategoryMenu>
-                        {v.sCategoryList.map((v) => (
-                          <li>{v.sCategoryDesc} </li>
-                        ))}
-                      </MCategoryMenu>
+                      <li onMouseEnter={() => setsHover(`${i}hover`)}>
+                        {v.mCategoryDesc}
+                      </li>
+                      {sHover === `${i}hover` && (
+                        <SCategoryMenu>
+                          {v.sCategoryList.map((v) => (
+                            <li>{v.sCategoryDesc} </li>
+                          ))}
+                        </SCategoryMenu>
+                      )}
                     </Fragment>
                   ))}
                 </MCategoryMenu>

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -23,7 +23,7 @@ const CategoryBox = styled.div`
   border: 1px solid green;
 `;
 
-const MCategoryMenu = styled.div`
+const MCategoryMenu = styled.ul`
   overflow: hidden;
   position: relative;
   top: 0;
@@ -41,18 +41,22 @@ function Category() {
   // console.log(CL.map((v) => v.lCategoryDesc));
   // console.log(CL?.map((v) => v.mCategoryList));
   const CLmList = CL?.map((v) => v.mCategoryList);
-  let sCLmList = [];
-  for (let i = 0; i < CLmList.length; i++) {
-    // console.log(CLmList[i].map((v) => v.mCategoryDesc));
-    sCLmList.push(CLmList[i].map((v) => v.sCategoryList));
-    // for (let j = 0; j < sCLmList.length; j++) {
-    //   console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
-    // }
-  }
-  // console.log(sCLmList);
-  for (let j = 0; j < sCLmList.length; j++) {
-    console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
-  }
+  console.log(CL[0].mCategoryList[7].sCategoryList.map((v) => v.sCategoryDesc));
+  console.log(
+    CLmList[0].map((v) => v.sCategoryList.map((v) => v.sCategoryDesc))
+  );
+  // let sCLmList = [];
+  // for (let i = 0; i < CLmList.length; i++) {
+  //   // console.log(CLmList[i].map((v) => v.mCategoryDesc));
+  //   sCLmList.push(CLmList[i].map((v) => v.sCategoryList));
+  //   // for (let j = 0; j < sCLmList.length; j++) {
+  //   //   console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
+  //   // }
+  // }
+  // // console.log(sCLmList);
+  // for (let j = 0; j < sCLmList.length; j++) {
+  //   console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
+  // }
 
   //sCategoryDesc
   // console.log(CLmList?.map((v) => v.mCategoryDesc));
@@ -67,20 +71,16 @@ function Category() {
               {v.lCategoryDesc}
               {hover === `${i}hover` && (
                 <MCategoryMenu>
-                  <ul>
-                    {CLmList[i].map((v, i) => (
-                      <Fragment key={v.mCategoryCode}>
-                        <li>{v.mCategoryDesc}</li>
-                        <MCategoryMenu>
-                          <ul>
-                            {sCLmList[i]?.map((v) => (
-                              <li>{v.sCategoryDesc}</li>
-                            ))}
-                          </ul>
-                        </MCategoryMenu>
-                      </Fragment>
-                    ))}
-                  </ul>
+                  {CLmList[i].map((v, i) => (
+                    <Fragment key={i}>
+                      <li>{v.mCategoryDesc}</li>
+                      <MCategoryMenu>
+                        {v.sCategoryList.map((v) => (
+                          <li>{v.sCategoryDesc} </li>
+                        ))}
+                      </MCategoryMenu>
+                    </Fragment>
+                  ))}
                 </MCategoryMenu>
               )}
             </CategoryBox>

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -16,23 +16,21 @@ const CategroyContainer = styled.div`
 
 const CategoryBox = styled.div`
   min-width: 15%;
-
+  max-width: 15%;
   min-height: 150px;
+  max-height: 150px;
   background-color: ${palette.gray[4]};
   border: 1px solid green;
 `;
 
 const MCategoryMenu = styled.div`
-  display: none;
+  overflow: hidden;
   position: relative;
   top: 0;
   width: 100%;
-  left: 110%;
+  left: calc(100% + 10px);
   min-width: 15%;
   border: 1px solid red;
-  .listhover {
-    display: flex;
-  }
 `;
 // hover시 드롭다운 리스트 생성, 2중 리스트까지 나와야함.
 // 해당 리스트를 출력할 수 있는 방법은?
@@ -42,30 +40,49 @@ function Category() {
   const CL = CategoryList.contents.categoryList;
   // console.log(CL.map((v) => v.lCategoryDesc));
   // console.log(CL?.map((v) => v.mCategoryList));
-  const test = CL?.map((v) => v.mCategoryList);
-  // for (let i = 0; i < test.length; i++) {
-  //   console.log(test[i].map((v) => v.mCategoryDesc));
-  // }
-  console.log(test?.map((v) => v.mCategoryDesc));
+  const CLmList = CL?.map((v) => v.mCategoryList);
+  let sCLmList = [];
+  for (let i = 0; i < CLmList.length; i++) {
+    // console.log(CLmList[i].map((v) => v.mCategoryDesc));
+    sCLmList.push(CLmList[i].map((v) => v.sCategoryList));
+    // for (let j = 0; j < sCLmList.length; j++) {
+    //   console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
+    // }
+  }
+  // console.log(sCLmList);
+  for (let j = 0; j < sCLmList.length; j++) {
+    console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
+  }
 
-  const [hover, setHover] = useState(false);
+  //sCategoryDesc
+  // console.log(CLmList?.map((v) => v.mCategoryDesc));
+
+  const [hover, setHover] = useState("");
   return (
-    <MainContainer>
+    <MainContainer onMouseLeave={() => setHover("")}>
       <CategroyContainer>
         {CL.map((v, i) => (
           <Fragment key={v.lCategoryCode}>
-            <CategoryBox
-              onMouseEnter={() => setHover(true)}
-              onMouseLeave={() => setHover(false)}
-            >
+            <CategoryBox onMouseEnter={() => setHover(`${i}hover`)}>
               {v.lCategoryDesc}
-              <MCategoryMenu className={`list${i} ${hover ? "hover" : ""}`}>
-                <ul>
-                  {test[i].map((v) => (
-                    <li key={v.mCategoryCode}>{v.mCategoryDesc}</li>
-                  ))}
-                </ul>
-              </MCategoryMenu>
+              {hover === `${i}hover` && (
+                <MCategoryMenu>
+                  <ul>
+                    {CLmList[i].map((v, i) => (
+                      <Fragment key={v.mCategoryCode}>
+                        <li>{v.mCategoryDesc}</li>
+                        <MCategoryMenu>
+                          <ul>
+                            {sCLmList[i]?.map((v) => (
+                              <li>{v.sCategoryDesc}</li>
+                            ))}
+                          </ul>
+                        </MCategoryMenu>
+                      </Fragment>
+                    ))}
+                  </ul>
+                </MCategoryMenu>
+              )}
             </CategoryBox>
           </Fragment>
         ))}

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -1,9 +1,9 @@
 import React, { Fragment, useState } from "react";
 import MainContainer from "../common/MainContainer";
-
 import styled from "styled-components";
 import { CategoryList } from "../../lib/documents/CategoryList";
 import palette from "../../lib/styles/palette";
+import Button from "../common/Button";
 
 const CategroyContainer = styled.div`
   display: flex;
@@ -11,75 +11,99 @@ const CategroyContainer = styled.div`
   gap: 10px 2%;
   width: 100%;
   height: auto;
-  background-color: rgba(255, 222, 120, 0.6);
+  background-color: rgb(255, 255, 255);
 `;
 
 const CategoryBox = styled.div`
-  width: 15%;
-
+  display: flex;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  margin: 0 auto;
+  width: 18%;
+  font-size: 1.2em;
   min-height: 150px;
   max-height: 150px;
   display: inline-block;
-  background-color: ${palette.gray[4]};
-  border: 1px solid green;
+  background-color: ${palette.gray[2]};
+  &:hover {
+    background-color: ${palette.orange[6]};
+    color: white;
+  }
 `;
 
 const MCategoryMenu = styled.ul`
-  left: ${CategoryBox.width};
+  color: black;
+  text-align: left;
   /* overflow: hidden; */
   /* display: flex; */
-  position: absolute;
+  position: relative;
+  width: 183px;
+  top: 0;
+  left: calc(90%);
   display: block;
-  width: ${CategoryBox.width};
   min-width: 15%;
-  border: 1px solid red;
+  border: 2px solid ${palette.orange[7]};
+  padding: 15px 0 0 10px;
+  line-height: 1.5;
+  font-size: 1em;
+  background-color: rgb(255, 255, 255);
+
+  li {
+    cursor: pointer;
+    &:hover {
+      border-bottom: 1px solid ${palette.orange[7]};
+    }
+  }
 `;
 
 const SCategoryMenu = styled.ul`
   position: absolute;
+  font-size: 0.8em;
+  width: 180px;
+  left: calc(90%);
   display: block;
-  width: ${CategoryBox.width};
   min-width: 15%;
-  border: 1px solid red;
+  padding: 4px;
+  border: 2px solid ${palette.orange[7]};
+  background-color: rgb(255, 255, 255);
+
+  li {
+    cursor: pointer;
+    &:hover {
+      border-bottom: 1px solid ${palette.orange[7]};
+    }
+  }
 `;
 // hover시 드롭다운 리스트 생성, 2중 리스트까지 나와야함.
 // 해당 리스트를 출력할 수 있는 방법은?
 //
+
+const ToggleButton = styled(Button)``;
 
 function Category() {
   const CL = CategoryList.contents.categoryList;
   // console.log(CL.map((v) => v.lCategoryDesc));
   // console.log(CL?.map((v) => v.mCategoryList));
   const CLmList = CL?.map((v) => v.mCategoryList);
-  console.log(CL[0].mCategoryList[7].sCategoryList.map((v) => v.sCategoryDesc));
-  console.log(
-    CLmList[0].map((v) => v.sCategoryList.map((v) => v.sCategoryDesc))
-  );
-  // let sCLmList = [];
-  // for (let i = 0; i < CLmList.length; i++) {
-  //   // console.log(CLmList[i].map((v) => v.mCategoryDesc));
-  //   sCLmList.push(CLmList[i].map((v) => v.sCategoryList));
-  //   // for (let j = 0; j < sCLmList.length; j++) {
-  //   //   console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
-  //   // }
-  // }
-  // // console.log(sCLmList);
-  // for (let j = 0; j < sCLmList.length; j++) {
-  //   console.log(sCLmList[j]?.map((v) => v.sCategoryDesc));
-  // }
-
-  //sCategoryDesc
-  // console.log(CLmList?.map((v) => v.mCategoryDesc));
+  // console.log(CL[0].mCategoryList[7].sCategoryList.map((v) => v.sCategoryDesc));
+  // console.log(
+  //   CLmList[0].map((v) => v.sCategoryList.map((v) => v.sCategoryDesc))
+  // );
 
   const [hover, setHover] = useState("");
   const [sHover, setsHover] = useState("");
   return (
-    <MainContainer onMouseLeave={() => setHover("")}>
+    <MainContainer>
+      <ToggleButton> test</ToggleButton>
       <CategroyContainer>
         {CL.map((v, i) => (
           <Fragment key={v.lCategoryCode}>
-            <CategoryBox onMouseEnter={() => setHover(`${i}hover`)}>
-              {v.lCategoryDesc}
+            <CategoryBox
+              onMouseEnter={() => setHover(`${i}hover`)}
+              onMouseLeave={() => setsHover("")}
+            >
+              <div>{v.lCategoryDesc}</div>
               {hover === `${i}hover` && (
                 <MCategoryMenu>
                   {CLmList[i].map((v, i) => (
@@ -87,10 +111,10 @@ function Category() {
                       <li onMouseEnter={() => setsHover(`${i}hover`)}>
                         {v.mCategoryDesc}
                       </li>
-                      {sHover === `${i}hover` && (
+                      {sHover === `${i}hover` && v.sCategoryList.length > 0 && (
                         <SCategoryMenu>
-                          {v.sCategoryList.map((v) => (
-                            <li>{v.sCategoryDesc} </li>
+                          {v.sCategoryList.map((v, i) => (
+                            <li key={i}>{v.sCategoryDesc} </li>
                           ))}
                         </SCategoryMenu>
                       )}

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -1,0 +1,12 @@
+import React from "react";
+import MainContainer from "../common/MainContainer";
+import TestBox from "../common/TestBox";
+function Category() {
+  return (
+    <MainContainer>
+      <TestBox></TestBox>
+    </MainContainer>
+  );
+}
+
+export default Category;

--- a/frontend/src/components/etc/Category.js
+++ b/frontend/src/components/etc/Category.js
@@ -1,10 +1,75 @@
-import React from "react";
+import React, { Fragment, useState } from "react";
 import MainContainer from "../common/MainContainer";
-import TestBox from "../common/TestBox";
+
+import styled from "styled-components";
+import { CategoryList } from "../../lib/documents/CategoryList";
+import palette from "../../lib/styles/palette";
+
+const CategroyContainer = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  gap: 10px 2%;
+  width: 100%;
+  height: auto;
+  background-color: rgba(255, 222, 120, 0.6);
+`;
+
+const CategoryBox = styled.div`
+  min-width: 15%;
+
+  min-height: 150px;
+  background-color: ${palette.gray[4]};
+  border: 1px solid green;
+`;
+
+const MCategoryMenu = styled.div`
+  display: none;
+  position: relative;
+  top: 0;
+  width: 100%;
+  left: 110%;
+  min-width: 15%;
+  border: 1px solid red;
+  .listhover {
+    display: flex;
+  }
+`;
+// hover시 드롭다운 리스트 생성, 2중 리스트까지 나와야함.
+// 해당 리스트를 출력할 수 있는 방법은?
+//
+
 function Category() {
+  const CL = CategoryList.contents.categoryList;
+  // console.log(CL.map((v) => v.lCategoryDesc));
+  // console.log(CL?.map((v) => v.mCategoryList));
+  const test = CL?.map((v) => v.mCategoryList);
+  // for (let i = 0; i < test.length; i++) {
+  //   console.log(test[i].map((v) => v.mCategoryDesc));
+  // }
+  console.log(test?.map((v) => v.mCategoryDesc));
+
+  const [hover, setHover] = useState(false);
   return (
     <MainContainer>
-      <TestBox></TestBox>
+      <CategroyContainer>
+        {CL.map((v, i) => (
+          <Fragment key={v.lCategoryCode}>
+            <CategoryBox
+              onMouseEnter={() => setHover(true)}
+              onMouseLeave={() => setHover(false)}
+            >
+              {v.lCategoryDesc}
+              <MCategoryMenu className={`list${i} ${hover ? "hover" : ""}`}>
+                <ul>
+                  {test[i].map((v) => (
+                    <li key={v.mCategoryCode}>{v.mCategoryDesc}</li>
+                  ))}
+                </ul>
+              </MCategoryMenu>
+            </CategoryBox>
+          </Fragment>
+        ))}
+      </CategroyContainer>
     </MainContainer>
   );
 }

--- a/frontend/src/components/etc/KdcSearch.js
+++ b/frontend/src/components/etc/KdcSearch.js
@@ -1,0 +1,128 @@
+import React, { Fragment, useState } from "react";
+import MainContainer from "../common/MainContainer";
+import styled from "styled-components";
+import { KDC } from "../../lib/documents/KDC";
+import palette from "../../lib/styles/palette";
+import { ToggleButton, ToggleContainer } from "./Category";
+
+const KDCContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: auto;
+  background-color: rgb(255, 255, 255);
+`;
+
+const TopicWrap = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const TopicBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.2em;
+  line-height: 1.5;
+  width: calc((100% - 54px) / 10);
+  height: 118px;
+  margin: 0 6px 0 0;
+  cursor: pointer;
+  background-color: ${palette.gray[4]};
+  &:hover {
+    background-color: ${palette.gray[6]};
+    color: white;
+  }
+  &.active {
+    background-color: ${palette.orange[7]};
+    color: white;
+  }
+`;
+
+const TopicDetailWrap = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const TopicDetailBox = styled.div`
+  padding: 10px 0;
+  line-height: 15px;
+  font-size: 1em;
+  display: grid;
+
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  li {
+    display: block;
+    font-size: 1em;
+    padding: 10px 0;
+    margin: 0 10px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    -webkit-line-clamp: 1;
+  }
+  li:first-child {
+    font-size: 1.2em;
+    border-top: 2px solid ${palette.gray[6]};
+    border-bottom: 2px solid ${palette.gray[6]};
+  }
+`;
+
+function KdcSearch() {
+  const [topic, setTopic] = useState("000");
+  const KDCList = KDC.contents.categoryList;
+  console.log(KDCList);
+  console.log(KDCList.map((v) => v.mCategoryList));
+  console.log(topic);
+  console.log();
+  const topicKDC = KDCList.map((v) => v.mCategoryList)[Number(topic.charAt())];
+  console.log(topicKDC);
+  console.log(topicKDC.map((v) => v.sCategoryList)[0]);
+  console.log(topicKDC.length);
+  const sTopicKDC = topicKDC.map((v) => v.sCategoryList);
+  console.log(sTopicKDC);
+  return (
+    <MainContainer>
+      <ToggleContainer>
+        <ToggleButton to='/categorySearch'>카테고리분류</ToggleButton>
+        <ToggleButton to='kdcSearch' className='active'>
+          한국십진분류
+        </ToggleButton>
+      </ToggleContainer>
+      <KDCContainer>
+        <TopicWrap>
+          {KDCList.map((v, i) => (
+            <TopicBox
+              key={i}
+              onClick={() => {
+                setTopic(v.lCategoryCode);
+              }}
+              className={topic === v.lCategoryCode ? "active" : ""}
+            >
+              <ul>
+                <li>{v.lCategoryCode}</li> <li>{v.lCategoryDesc}</li>
+              </ul>
+            </TopicBox>
+          ))}
+        </TopicWrap>
+        <TopicDetailWrap>
+          <TopicDetailBox>
+            {topicKDC.map((v, i) => (
+              <ul key={i}>
+                <li>
+                  {v.mCategoryCode} {v.mCategoryDesc}
+                </li>
+                {sTopicKDC[i].map((v) => (
+                  <li key={v.sCategoryCode}>
+                    {v.sCategoryCode} {v.sCategoryDesc}
+                  </li>
+                ))}
+              </ul>
+            ))}
+          </TopicDetailBox>
+        </TopicDetailWrap>
+      </KDCContainer>
+    </MainContainer>
+  );
+}
+
+export default KdcSearch;

--- a/frontend/src/components/etc/KdcSearch.js
+++ b/frontend/src/components/etc/KdcSearch.js
@@ -70,16 +70,9 @@ const TopicDetailBox = styled.div`
 function KdcSearch() {
   const [topic, setTopic] = useState("000");
   const KDCList = KDC.contents.categoryList;
-  console.log(KDCList);
-  console.log(KDCList.map((v) => v.mCategoryList));
-  console.log(topic);
-  console.log();
   const topicKDC = KDCList.map((v) => v.mCategoryList)[Number(topic.charAt())];
-  console.log(topicKDC);
-  console.log(topicKDC.map((v) => v.sCategoryList)[0]);
-  console.log(topicKDC.length);
   const sTopicKDC = topicKDC.map((v) => v.sCategoryList);
-  console.log(sTopicKDC);
+
   return (
     <MainContainer>
       <ToggleContainer>

--- a/frontend/src/pages/CategorySearch.js
+++ b/frontend/src/pages/CategorySearch.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Category from "../components/etc/Category";
 import SiteRootNavContainer from "../container/common/SiteRootNavContainer";
 
 function CategorySearch() {
@@ -6,6 +7,7 @@ function CategorySearch() {
   return (
     <>
       <SiteRootNavContainer title={title}></SiteRootNavContainer>
+      <Category></Category>
     </>
   );
 }

--- a/frontend/src/pages/KdcSearchPage.js
+++ b/frontend/src/pages/KdcSearchPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import KdcSearch from "../components/etc/KdcSearch";
 import SiteRootNavContainer from "../container/common/SiteRootNavContainer";
 
 function KdcSearchPage() {
@@ -6,6 +7,7 @@ function KdcSearchPage() {
   return (
     <>
       <SiteRootNavContainer title={title}></SiteRootNavContainer>
+      <KdcSearch></KdcSearch>
     </>
   );
 }


### PR DESCRIPTION
## 세부사항
카테고리분류/ 한국십진분류 선택 컴포넌트
카테고리분류
카테고리 분류 json 파일 크롤링해서 제작 - (CategoryList.js)
드롭다운 기능(hover시작동) -2중 드롭다운
아이콘 hover시 색 변경

한국십진분류
tab기능 클릭시 페이지 출력 변경
분류 선택시, hover시 색 변경

## 어려웠던 점 & 참고사항
3중 드롭다운 페이지 생성
 useRef를 사용하라는 조언을 받았는데 해당 hook을 이용하지 않고 작성
styled components 에서 active 및 hover로 동작하는게 제대로 동작하지 않았는데 단순 실수
-> className을 styled components에서 쓸 때 &을 앞에 붙여주어야함.
그리고 연산자(&&)을 써서 구현
3중 객체의 결과값을 가져오기 위해서 해당 구조를 나눠서 렌더링하면 편했는데 한번에 출력해보고 싶어서 코드가 난해해짐. 다음에는 좀 더 클린 코드를 작성할 수 있길.

구현하지 않은 것 : 
1. 원본 페이지에서는 분류별 이미지가 존재하는데 해당 이미지 삽입 생략
2. 반응형 페이지
    데스크탑 환경에서 최적화되어있음.


## 스크린샷
![image](https://user-images.githubusercontent.com/35355087/196894595-fb2a16f7-24ba-40bd-9c8b-8539ebf68e31.png)
![image](https://user-images.githubusercontent.com/35355087/196894697-65ba430b-a1e6-4a5c-8c24-8a7d843ed695.png)

## 실제 소요시간
이틀

## 관련이슈
#14 #15 