### PR TITLE
개별 페이지 생성

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,5 +52,5 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "./"
+  "homepage": "./librarySearch/"
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import KdcSearchPage from "./pages/KdcSearchPage";
 import Footer from "./components/common/Footer";
 import Redirect from "./pages/Redirect";
 import AuthPage from "./pages/AuthPage";
+import SingleBookPage from "./pages/SingleBookPage";
 import { useAuthContext } from "./components/auth/hooks/useAuthContext";
 
 function App() {
@@ -33,6 +34,7 @@ function App() {
         <Route path='/redirectB' element={<Redirect url={url2} />}></Route>
         <Route path='/auth' element={!user ? <AuthPage /> : null}></Route>
         {/* 임시로 null값을 넣어놨는데 잘못된 경로입니다 Page만들어야할 듯? */}
+        <Route path='/singleBook/:id' element={<SingleBookPage />}></Route>
       </Routes>
       <Footer></Footer>
     </>

--- a/frontend/src/components/api/BookRender.js
+++ b/frontend/src/components/api/BookRender.js
@@ -17,7 +17,7 @@ import DateFilter, {
   startDt,
   endDt,
 } from "../fillter/DateFilter";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 const API_KEY = process.env.REACT_APP_DATA4LIBRARY_KEY;
 
@@ -267,21 +267,26 @@ function BookRender(props) {
             })
             .map((DB, i) => {
               return (
-                <li key={`${DB.isbn13} ${DB.vol} ${i + 1}`}>
-                  <h2>{i + 1}</h2>
-                  <BookImage
-                    style={{
-                      backgroundImage: `url(${
-                        DB.bookImageURL ? DB.bookImageURL : no_image
-                      })`,
-                    }}
-                  ></BookImage>
+                <Link
+                  to={`/singleBook/${DB.isbn13}`}
+                  key={`${DB.isbn13} ${DB.vol} ${i + 1}`}
+                >
+                  <li>
+                    <h2>{i + 1}</h2>
+                    <BookImage
+                      style={{
+                        backgroundImage: `url(${
+                          DB.bookImageURL ? DB.bookImageURL : no_image
+                        })`,
+                      }}
+                    ></BookImage>
 
-                  <p>
-                    {DB.bookname} {DB.vol ? `= ${DB.vol}` : null}
-                  </p>
-                  <p>{DB.authors}</p>
-                </li>
+                    <p>
+                      {DB.bookname} {DB.vol ? `= ${DB.vol}` : null}
+                    </p>
+                    <p>{DB.authors}</p>
+                  </li>
+                </Link>
               );
             })
             .slice(offSet, offSet + limit)}

--- a/frontend/src/components/api/BookRender.js
+++ b/frontend/src/components/api/BookRender.js
@@ -269,6 +269,17 @@ function BookRender(props) {
               return (
                 <Link
                   to={`/singleBook/${DB.isbn13}`}
+                  state={{
+                    author: DB.authors,
+                    bookImageURL: DB.bookImageURL,
+                    bookname: DB.bookname,
+                    class_nm: DB.class_nm,
+                    class_no: DB.class_no,
+                    isbn13: DB.isbn13,
+                    publisher: DB.publisher,
+                    vol: DB.vol,
+                    publication_year: DB.publication_year,
+                  }}
                   key={`${DB.isbn13} ${DB.vol} ${i + 1}`}
                 >
                   <li>

--- a/frontend/src/components/etc/SingleBook.js
+++ b/frontend/src/components/etc/SingleBook.js
@@ -21,7 +21,9 @@ const BookImage = styled.div.attrs({ type: "Image" })`
   height: 180px;
 `;
 
-const BookContainer = styled.div``;
+const BookContainer = styled.div`
+  width: 100%;
+`;
 
 const BookName = styled.div`
   font-size: 2em;
@@ -34,14 +36,14 @@ const BookDetail = styled.div`
 
 const KDCList = styled.div``;
 
-const InfoLibrary = styled.div``;
+// const InfoLibrary = styled.div``;
 
 function SingleBook(props) {
   const location = useLocation();
   const book = location.state;
 
   const [data, setData] = useState({ response: {} });
-  const [libData, setLibData] = useState({ response: {} });
+  // const [libData, setLibData] = useState({ response: {} });
 
   useEffect(() => {
     (async () => {
@@ -56,23 +58,24 @@ function SingleBook(props) {
     })();
   }, [book]);
 
-  // 도서관코드 출력
-  const libArr = data.response.libs?.map((v) => v.lib.libCode);
-  console.log(libArr[0]);
-  useEffect(() => {
-    (async () => {
-      try {
-        let libres = await fetch(
-          `https://library-simple-proxy.herokuapp.com/http://data4library.kr/api/bookExist?authKey=${API_KEY}&isbn13=${book.isbn13}&libCode=${libArr[0]}&format=json`
-        );
-        libres.json().then((libData) => setLibData(libData));
-      } catch (e) {
-        console.log(`${e} error가 발생했습니다.`);
-      }
-    })();
-  }, [book]);
+  // // 도서관코드 출력
+  // const libArr = data.response.libs?.map((v) => v.lib.libCode);
+  // console.log(libArr[0]);
+  // useEffect(() => {
+  //   (async () => {
+  //     try {
+  //       let libres = await fetch(
+  //         `https://library-simple-proxy.herokuapp.com/http://data4library.kr/api/bookExist?authKey=${API_KEY}&isbn13=${book.isbn13}&libCode=${libArr[0]}&format=json`
+  //       );
+  //       libres.json().then((libData) => setLibData(libData));
+  //     } catch (e) {
+  //       console.log(`${e} error가 발생했습니다.`);
+  //     }
+  //   })();
+  // }, [book]);
 
-  console.log(libData.response.result);
+  // console.log(libData.response.result);
+
   // 6. 도서 상세 조회
   // 7. 도서 키워드 목록
   // 8. 도서별 이용분석
@@ -108,7 +111,7 @@ function SingleBook(props) {
           <KDCList>한국십진분류 : {book.class_nm}</KDCList>
         </BookContainer>
       </DetailContainer>
-      <InfoLibrary>{book.isbn13}</InfoLibrary>
+      {/* <InfoLibrary>{book.isbn13}</InfoLibrary> */}
     </MainContainer>
   );
 }

--- a/frontend/src/components/etc/SingleBook.js
+++ b/frontend/src/components/etc/SingleBook.js
@@ -1,9 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import MainContainer from "../common/MainContainer";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import palette from "../../lib/styles/palette";
 import no_image from "../../lib/img/book_img/no-image-MO.jpg";
+
+const API_KEY = process.env.REACT_APP_DATA4LIBRARY_KEY;
 
 const DetailContainer = styled.div`
   padding: 20px;
@@ -32,12 +34,33 @@ const BookDetail = styled.div`
 
 const KDCList = styled.div``;
 
+const InfoLibrary = styled.div``;
+
 function SingleBook(props) {
   const location = useLocation();
   console.log(location);
   console.log(location.state.author);
   console.log(props.id);
   const book = location.state;
+
+  const [data, setData] = useState({ response: {} });
+
+  useEffect(() => {
+    (async () => {
+      try {
+        let res = await fetch(
+          `https://library-simple-proxy.herokuapp.com/http://data4library.kr/api/libSrchByBook?authKey=${API_KEY}&isbn=${book.isbn13}&region=31&dtl_region=31011&format=json`
+        );
+        res.json().then((data) => setData(data));
+      } catch (e) {
+        console.log(`${e} error가 발생했습니다.`);
+      }
+    })();
+  }, [book]);
+
+  console.log(data.response.libs);
+  const libArr = data.response.libs?.map((v) => v.lib.libCode);
+  console.log(libArr);
   // 6. 도서 상세 조회
   // 7. 도서 키워드 목록
   // 8. 도서별 이용분석
@@ -48,6 +71,12 @@ function SingleBook(props) {
   // 인기도서/추천도서 페이지에서 상세정보 페이지로 이동하는 링크달기
   // 인기도서/추천도서 페이지에서 해당 정보를 전달해서 출력
   // 이후 검색해서 상세정보페이지 가져오는 정보를 확인 해당 정보와 인기도서/추천도서 페이지 교차검증하여 출력
+  // 전체도서관 소장 정보
+  // - 13. 도서 소장 도서관 조회 (isbn으로 검색)- 지역별 -> 도서관 코드 출력
+  // - 위에서 가져온 도서관코드를 바탕으로 11. 도서관별 도서 소장여부 및 대추가능여부 조회(도서관코드, isbn13자리 필요) -> 도서 소장여부, 대출 가능여부
+  // 책소개 6. 도서 상세조회 isbn13자리로 검색 -> 책소개(description) 출력
+  // 이 자료와 함께 대출한 자료 - 8. 도서별 이용분석 isbn13자리로 검색 -> colLoanBook
+  // 태그 클라우드 7.도서 키워드목록 또는 8. 도서별이용분석 - isbn13자리로 검색 -  weight(가중치)
 
   return (
     <MainContainer>
@@ -67,6 +96,7 @@ function SingleBook(props) {
           <KDCList>한국십진분류 : {book.class_nm}</KDCList>
         </BookContainer>
       </DetailContainer>
+      <InfoLibrary>{book.isbn13}</InfoLibrary>
     </MainContainer>
   );
 }

--- a/frontend/src/components/etc/SingleBook.js
+++ b/frontend/src/components/etc/SingleBook.js
@@ -1,10 +1,74 @@
-import React from "react";
+import React, { useEffect } from "react";
 import MainContainer from "../common/MainContainer";
+import { useLocation } from "react-router-dom";
+import styled from "styled-components";
+import palette from "../../lib/styles/palette";
+import no_image from "../../lib/img/book_img/no-image-MO.jpg";
+
+const DetailContainer = styled.div`
+  padding: 20px;
+  display: flex;
+`;
+
+const BookImage = styled.div.attrs({ type: "Image" })`
+  display: flex;
+  background-position: center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  width: 30%;
+  height: 180px;
+`;
+
+const BookContainer = styled.div``;
+
+const BookName = styled.div`
+  font-size: 2em;
+  padding-top: 1em;
+`;
+
+const BookDetail = styled.div`
+  font-size: 1.5em;
+`;
+
+const KDCList = styled.div``;
 
 function SingleBook(props) {
+  const location = useLocation();
+  console.log(location);
+  console.log(location.state.author);
   console.log(props.id);
+  const book = location.state;
+  // 6. 도서 상세 조회
+  // 7. 도서 키워드 목록
+  // 8. 도서별 이용분석
+  // 11. 도서관별 도서 소장여부 및 대출 가능여부 조회
+  // 13. 도서 소장 도서관 조회
+  // 인기도서/추천도서 등 페이지에서 들어오는 경우 해당 책의 정보를 가져오면되지만...
+  // 검색해서 들어오는 경우 해당 책의 정보를 가져오려면...
+  // 인기도서/추천도서 페이지에서 상세정보 페이지로 이동하는 링크달기
+  // 인기도서/추천도서 페이지에서 해당 정보를 전달해서 출력
+  // 이후 검색해서 상세정보페이지 가져오는 정보를 확인 해당 정보와 인기도서/추천도서 페이지 교차검증하여 출력
 
-  return <MainContainer>singelBook Page rendering test</MainContainer>;
+  return (
+    <MainContainer>
+      <DetailContainer>
+        <BookImage
+          style={{
+            backgroundImage: `url(${
+              book.bookImageURL ? book.bookImageURL : no_image
+            })`,
+          }}
+        ></BookImage>
+        <BookContainer>
+          <BookName>{book.bookname}</BookName>
+          <BookDetail>
+            {`${book.author} | ${book.publisher} | ${book.publication_year}`}
+          </BookDetail>
+          <KDCList>한국십진분류 : {book.class_nm}</KDCList>
+        </BookContainer>
+      </DetailContainer>
+    </MainContainer>
+  );
 }
 
 export default SingleBook;

--- a/frontend/src/components/etc/SingleBook.js
+++ b/frontend/src/components/etc/SingleBook.js
@@ -1,0 +1,10 @@
+import React from "react";
+import MainContainer from "../common/MainContainer";
+
+function SingleBook(props) {
+  console.log(props.id);
+
+  return <MainContainer>singelBook Page rendering test</MainContainer>;
+}
+
+export default SingleBook;

--- a/frontend/src/components/etc/SingleBook.js
+++ b/frontend/src/components/etc/SingleBook.js
@@ -38,12 +38,10 @@ const InfoLibrary = styled.div``;
 
 function SingleBook(props) {
   const location = useLocation();
-  console.log(location);
-  console.log(location.state.author);
-  console.log(props.id);
   const book = location.state;
 
   const [data, setData] = useState({ response: {} });
+  const [libData, setLibData] = useState({ response: {} });
 
   useEffect(() => {
     (async () => {
@@ -58,9 +56,23 @@ function SingleBook(props) {
     })();
   }, [book]);
 
-  console.log(data.response.libs);
+  // 도서관코드 출력
   const libArr = data.response.libs?.map((v) => v.lib.libCode);
-  console.log(libArr);
+  console.log(libArr[0]);
+  useEffect(() => {
+    (async () => {
+      try {
+        let libres = await fetch(
+          `https://library-simple-proxy.herokuapp.com/http://data4library.kr/api/bookExist?authKey=${API_KEY}&isbn13=${book.isbn13}&libCode=${libArr[0]}&format=json`
+        );
+        libres.json().then((libData) => setLibData(libData));
+      } catch (e) {
+        console.log(`${e} error가 발생했습니다.`);
+      }
+    })();
+  }, [book]);
+
+  console.log(libData.response.result);
   // 6. 도서 상세 조회
   // 7. 도서 키워드 목록
   // 8. 도서별 이용분석

--- a/frontend/src/container/common/SingleBookContainer.js
+++ b/frontend/src/container/common/SingleBookContainer.js
@@ -1,0 +1,8 @@
+import React from "react";
+import SingleBook from "../../components/etc/SingleBook";
+function SingleBookContainer(props) {
+  let id = props.id;
+  return <SingleBook id={id}></SingleBook>;
+}
+
+export default SingleBookContainer;

--- a/frontend/src/pages/SingleBookPage.js
+++ b/frontend/src/pages/SingleBookPage.js
@@ -5,21 +5,11 @@ import { useParams } from "react-router-dom";
 
 function SingleBookPage() {
   let { id } = useParams();
-  // 6. 도서 상세 조회
-  // 7. 도서 키워드 목록
-  // 8. 도서별 이용분석
-  // 11. 도서관별 도서 소장여부 및 대출 가능여부 조회
-  // 13. 도서 소장 도서관 조회
-  // 인기도서/추천도서 등 페이지에서 들어오는 경우 해당 책의 정보를 가져오면되지만...
-  // 검색해서 들어오는 경우 해당 책의 정보를 가져오려면...
-  // 인기도서/추천도서 페이지에서 상세정보 페이지로 이동하는 링크달기
-  // 인기도서/추천도서 페이지에서 해당 정보를 전달해서 출력
-  // 이후 검색해서 상세정보페이지 가져오는 정보를 확인 해당 정보와 인기도서/추천도서 페이지 교차검증하여 출력
+
   const title = "상세정보";
   return (
     <>
       <SiteRootNavContainer title={title}></SiteRootNavContainer>
-      <p>현재 페이지의 파라미터는 {id}입니다</p>
       <SingleBookContainer id={id}></SingleBookContainer>
     </>
   );

--- a/frontend/src/pages/SingleBookPage.js
+++ b/frontend/src/pages/SingleBookPage.js
@@ -1,0 +1,28 @@
+import React from "react";
+import SiteRootNavContainer from "../container/common/SiteRootNavContainer";
+import SingleBookContainer from "../container/common/SingleBookContainer";
+import { useParams } from "react-router-dom";
+
+function SingleBookPage() {
+  let { id } = useParams();
+  // 6. 도서 상세 조회
+  // 7. 도서 키워드 목록
+  // 8. 도서별 이용분석
+  // 11. 도서관별 도서 소장여부 및 대출 가능여부 조회
+  // 13. 도서 소장 도서관 조회
+  // 인기도서/추천도서 등 페이지에서 들어오는 경우 해당 책의 정보를 가져오면되지만...
+  // 검색해서 들어오는 경우 해당 책의 정보를 가져오려면...
+  // 인기도서/추천도서 페이지에서 상세정보 페이지로 이동하는 링크달기
+  // 인기도서/추천도서 페이지에서 해당 정보를 전달해서 출력
+  // 이후 검색해서 상세정보페이지 가져오는 정보를 확인 해당 정보와 인기도서/추천도서 페이지 교차검증하여 출력
+  const title = "상세정보";
+  return (
+    <>
+      <SiteRootNavContainer title={title}></SiteRootNavContainer>
+      <p>현재 페이지의 파라미터는 {id}입니다</p>
+      <SingleBookContainer id={id}></SingleBookContainer>
+    </>
+  );
+}
+
+export default SingleBookPage;


### PR DESCRIPTION
## 세부 사항
개별페이지 생성

## 어려웠던 점 & 참고사항
 신착도서 혹은 인기도서 페이지에서 데이터를 받아와서 개별 도서 페이지를 생성할 때
어떤 api를 기준으로 출력해야할지 고민을 오래했다.
react-router-dom의 link를 이용하여 데이터를 전달하는데 있어 약간의 시행착오가 있었다.
원래 페이지에서 제공하는 다양한 기능(도서관 서가정보, 책소개, 태그 클라우드 등)에 대해서는 추후 순차적으로 기능을 만들어야할 듯 하다.

## 스크린샷
![image](https://user-images.githubusercontent.com/35355087/197913813-3a03900a-5cc6-4632-a374-da0203cc7aa9.png)


## 실제 소요시간
12시간

## 관련 이슈
#29 
